### PR TITLE
Adds the local path as a partials path when rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # PunyBlog changelog
 
+  - v1.5.0 (2023-09-30)
+    - Feature: Allows nunjucks includes (`{% include "file" %}`) from the same path as the current markdown file being rendered
+      - This means you can now include markdown files from the same folder as the current markdown file
+      - See [Github issue](https://github.com/kpander/punyblog/issues/24)
+
   - v1.4.3 (2023-09-07)
     - Maintenance: Updates cachebust package
 

--- a/lib/PunyBlog.js
+++ b/lib/PunyBlog.js
@@ -34,7 +34,12 @@ module.exports = class PunyBlog {
 
       let html;
       try {
-        html = renderer.toHtml(markdown);
+        // Provide the path to the markdown file we're rendering, so we can
+        // include partials from that same path if needed.
+        const options = {
+          path_partials_local: path.dirname(filename_md),
+        };
+        html = renderer.toHtml(markdown, options);
       } catch (err) {
         this._log.error(`[${Log.currentFn}] Error rendering file: ${filename_md}`);
         this._log.error(`[${Log.currentFn}] Config:`, this._config);

--- a/lib/RenderHtml.js
+++ b/lib/RenderHtml.js
@@ -17,14 +17,12 @@ const Log = require("../util/Log");
 
 module.exports = class RenderHtml {
   constructor(config = {}, logger) {
-    const options = {};
     if (typeof config.path_partials === "string") {
       config.path_partials = [ config.path_partials ];
     } else if (!Array.isArray(config.path_partials)) {
       config.path_partials = [];
     }
     this._path_partials = [ ...config.path_partials, path.join(__dirname, "../partials") ];
-    this.nunjucks_env = nunjucks.configure(this._path_partials, options);
     this._config = config;
     this._log = logger;
   }
@@ -36,9 +34,20 @@ module.exports = class RenderHtml {
    * for nunjucks rendering errors (with the markup, the partials, etc.).
    *
    * @param string markdown content to be rendered into HTML
+   * @param object options = optional configuration for rendering
+   *   - string path_partials_local
+   *     - if provided, prepend this path to the partial paths to use
+   *
    * @return string html
    */
-  toHtml(markdown) {
+  toHtml(markdown, options = {}) {
+    if (options && options.path_partials_local) {
+      const paths = [ options.path_partials_local, ...this._path_partials ];
+      this.nunjucks_env = nunjucks.configure(paths, {});
+    } else {
+      this.nunjucks_env = nunjucks.configure(this._path_partials, {});
+    }
+
     // Split the text content into a front matter object and raw markdown body.
     const data = fm(markdown);
     const vars = { ...this._config.template_vars, ...data.attributes };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kpander/punyblog",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kpander/punyblog",
-      "version": "1.4.3",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "@kpander/cachebust": "^1.1.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kpander/punyblog",
   "description": "Render markdown files into a static website",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "homepage": "https://github.com/kpander/punyblog",
   "author": {
     "name": "Kendall Anderson",

--- a/test/PunyBlog.test.js
+++ b/test/PunyBlog.test.js
@@ -173,6 +173,48 @@ test(
     expect(fs.existsSync(filename)).toEqual(true);
   });
 });
+
+test(
+  `[PunyBlog-006]
+  Given
+    - a configuration option where the src path exists
+    - a configuration option where the dist path exists
+    - a src path with a markdown file
+    - a partial, referenced in a markdown file, that exists only in the same folder as a markdown file
+  When
+    - we build
+  Then
+    - we should receive true
+    - the rendered html should include the contents of the partial from the markdown file path
+`.trim(), async() => {
+  // Given...
+  const tmpobj1 = tmp.dirSync();
+  const tmpobj2 = tmp.dirSync();
+  const tmpobj3 = tmp.dirSync();
+  const path_src = tmpobj1.name;
+  const path_dest = tmpobj2.name;
+
+  createMarkdownFile(path_src, "index.md", `# my header {% include "my-partial.html" %}`);
+  createMarkdownFile(path_src, "my-partial.html", "THIS IS MY PARTIAL");
+
+  const expected_file = path.join(path_dest, "index.html");
+
+  const config = {
+    path_src: path_src,
+    path_dest: path_dest,
+  };
+  const punyBlog = new PunyBlog(config);
+
+  // When...
+  const result = punyBlog.build();
+
+  // Then...
+  expect(result).toEqual(true);
+  expect(fs.existsSync(expected_file)).toEqual(true);
+  const contents = fs.readFileSync(expected_file, "utf8");
+  expect(contents.indexOf("THIS IS MY PARTIAL")).not.toEqual(-1);
+});
+
 });
 
 describe("Static files:", () => {


### PR DESCRIPTION
This configures nunjucks to additionally use the path of the source file as a partials path when rendering.