### PR TITLE
Removes empty <p> tags from the rendered output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # PunyBlog changelog
 
+  - v1.8.0 (2023-11-18)
+    - Feature: Empty `<p></p>` tags are removed from the final HTML
+      - These are typically caused by Nunjucks comments/conditions/etc.
+      - See [Github issue](https://github.com/kpander/punyblog/issues/30)
+
   - v1.7.0 (2023-11-17)
     - Feature: Adds public property `punyBlogInstance.documents` which returns an object with all markdown documents, their frontmatter, and contents
       - See [Github issue](https://github.com/kpander/punyblog/issues/28)

--- a/lib/RenderHtml.js
+++ b/lib/RenderHtml.js
@@ -63,7 +63,8 @@ ${html}
 {% endblock %}
 `;
 
-    return nunjucks.renderString(html, vars);
+    html = nunjucks.renderString(html, vars);
+    return Util.replaceAll(html, "<p></p>", "");
   }
 
   _get_template_file(attrs = {}) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kpander/punyblog",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kpander/punyblog",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "@kpander/cachebust": "^1.1.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kpander/punyblog",
   "description": "Render markdown files into a static website",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "homepage": "https://github.com/kpander/punyblog",
   "author": {
     "name": "Kendall Anderson",

--- a/test/RenderHtml.test.js
+++ b/test/RenderHtml.test.js
@@ -304,4 +304,36 @@ test(
   expect(result).toEqual("my custom template");
 });
 
+test(
+  `[RenderHtml-clean-001]
+  Given
+    - a string with nunjucks comments and markdown markup
+  When
+    - we run render()
+  Then
+    - we should not have an empty <p></p> tag that wrapped the nunjucks comment
+`.trim(), async() => {
+  // Given...
+  const tmpobj = tmp.dirSync();
+  const config = {};
+  const renderHtml = new RenderHtml(config);
+
+  const markdown = `
+Line 1.
+
+{#
+this is a nunjucks comment
+#}
+
+Line 2.
+`.trim();
+
+  // When...
+  const result = renderHtml.toHtml(markdown).trim();
+  const search = "<p></p>";
+
+  // Then...
+  expect(result.indexOf(search)).toEqual(-1);
+});
+
 


### PR DESCRIPTION
These are usually caused by Nunjucks items (such as comments, or variable setting, etc.).