### PR TITLE
Fixes rendering bug that breaks nunjucks macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # PunyBlog changelog
 
+  - v1.9.1 (2023-12-15)
+    - Bugfix: Fixes nunjucks variable and macro calls, when they include quotes
+      - Nunjucks macro calls (e.g., `mymacro("somevalue")`) were breaking, because quotes were replaced with entities
+      - Telling the markdown renderer to not escape quotes doesn't seem to address this, which is why (at this time) this hacky fix is in place
+
   - v1.9.0 (2023-11-24)
     - Feature: Adds template variables for current file being rendered
       - `{{ render.current.basename }}` - the current base HTML file (e.g., index.html)

--- a/lib/RenderHtml.js
+++ b/lib/RenderHtml.js
@@ -92,7 +92,7 @@ ${html}
    * @return string html = the fixed html content
    */
   _fix_nunjucks_quoting(html) {
-    const regex = new RegExp(/{%(.*)&(quot|apos);(.*?)&(quot|apos);(.*?)%}/gi);
+    const regex = new RegExp(/({{|{%)(.*)&(quot|apos);(.*?)&(quot|apos);(.*?)(%}|}})/gi);
     const matches = html.match(regex);
     if (matches === null) return html;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kpander/punyblog",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kpander/punyblog",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "license": "MIT",
       "dependencies": {
         "@kpander/cachebust": "^1.1.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kpander/punyblog",
   "description": "Render markdown files into a static website",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "homepage": "https://github.com/kpander/punyblog",
   "author": {
     "name": "Kendall Anderson",

--- a/test/RenderHtml.test.js
+++ b/test/RenderHtml.test.js
@@ -336,4 +336,35 @@ Line 2.
   expect(result.indexOf(search)).toEqual(-1);
 });
 
+test(
+  `[RenderHtml-entity-001]
+  Given
+    - a string with a nunjucks macro definition, and call
+  When
+    - we run render()
+  Then
+    - the macro should work as expected
+`.trim(), async() => {
+  // Given...
+  const renderHtml = new RenderHtml({});
+
+  const markdown = `
+{% macro myfunc(myvar) %}
+<h3>{{ myvar }}</h3>
+{% endmacro %}
+
+{{ myfunc("my test string") }}
+
+test
+
+`.trim();
+
+  // When...
+  const result = renderHtml.toHtml(markdown).trim();
+  const search = "<h3>my test string</h3>";
+
+  // Then...
+  expect(result.indexOf(search)).not.toEqual(-1);
+});
+
 


### PR DESCRIPTION
Fix is a hack, in that we're trying to reverse entity quoting that seems to be be caused by the markdown renderer. (Trying to limit the markdown renderer doesn't fix it, so we've resorted to string matching...)